### PR TITLE
Upgrade Trifid to 4.0.3 + improve HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.2.8",
       "license": "UNLICENSED",
       "dependencies": {
-        "trifid": "^4.0.2"
+        "trifid": "^4.0.3"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
+      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.1.tgz",
-      "integrity": "sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
+      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
       "engines": {
         "node": ">=14"
       }
@@ -88,24 +88,24 @@
       }
     },
     "node_modules/@graphy/content.nq.read": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@graphy/content.nq.read/-/content.nq.read-4.3.4.tgz",
-      "integrity": "sha512-Z438rZfkfzn7MgpCZGDfdA7zlkMEsc2sF/egTkiyqXj2tjLg3cQKdMYADcFQBxozk0bPqhsqCN3GWjYvE+R/Lg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@graphy/content.nq.read/-/content.nq.read-4.3.7.tgz",
+      "integrity": "sha512-Q1wDp7BK9JLHOgkUu3YW5+HoSo6YKDNQxvfJ8Rrsy4sNXFxuaodx5XjyYjChKoQ0svFw/CZht3A5ndECJPIANw==",
       "dependencies": {
-        "@graphy/core.data.factory": "^4.3.4",
-        "@graphy/core.iso.stream": "^4.3.4"
+        "@graphy/core.data.factory": "^4.3.7",
+        "@graphy/core.iso.stream": "^4.3.7"
       },
       "engines": {
         "node": ">=8.4.0"
       }
     },
     "node_modules/@graphy/content.trig.read": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@graphy/content.trig.read/-/content.trig.read-4.3.4.tgz",
-      "integrity": "sha512-kShOOxR/OgK/cX/rlkcAyGtwc2kPdvQv2KBEMrrqGLMwQoRUDZiYOZlwepmRTX84KR3gYXpCh78OsftjuIVAiA==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@graphy/content.trig.read/-/content.trig.read-4.3.7.tgz",
+      "integrity": "sha512-8ff6DB/2zAULSnSr1vU0JpjZQ9SJFxEoYLUtz7P1WUCFbAAV6+RAXDjpJEVqhyCKAVdiozc1Zp7JUh4np3q3Ag==",
       "dependencies": {
-        "@graphy/core.data.factory": "^4.3.4",
-        "@graphy/core.iso.stream": "^4.3.4",
+        "@graphy/core.data.factory": "^4.3.7",
+        "@graphy/core.iso.stream": "^4.3.7",
         "uri-js": "^4.4.0"
       },
       "engines": {
@@ -113,12 +113,12 @@
       }
     },
     "node_modules/@graphy/content.trig.write": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@graphy/content.trig.write/-/content.trig.write-4.3.4.tgz",
-      "integrity": "sha512-mRQF/B/KZV1b1isw+UOJUm7auzwnfqUt7U670mNjTpa5fdfnqVWtMIEPMkD2o+Wis87UKejjUojNPAFfFBZ85g==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@graphy/content.trig.write/-/content.trig.write-4.3.7.tgz",
+      "integrity": "sha512-NrzWQ3QC/nZwbSnyaW6npVSw2bEQwfCBQfyfnwASGDbtRleSH60jEQcaka3INhfIf25uWZ/XK4TgLS2mCbdXlA==",
       "dependencies": {
-        "@graphy/core.class.writable": "^4.3.4",
-        "@graphy/core.data.factory": "^4.3.4",
+        "@graphy/core.class.writable": "^4.3.7",
+        "@graphy/core.data.factory": "^4.3.7",
         "big-integer": "^1.6.48"
       },
       "engines": {
@@ -126,12 +126,12 @@
       }
     },
     "node_modules/@graphy/content.ttl.write": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@graphy/content.ttl.write/-/content.ttl.write-4.3.4.tgz",
-      "integrity": "sha512-riXl3z7xP6cVG9rnBtpDckmMFikVQr3kcmfTMR3mB+LTR3JAMO5BGS5NOHu5kWW4wKTCvS6rJRD5N+WrxeDxtg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@graphy/content.ttl.write/-/content.ttl.write-4.3.7.tgz",
+      "integrity": "sha512-QpSa3lMmU+DA8udvikrPDji+XvUf5wfU4ShhqXU9mQEdccDTNw/eOOlhtLITAC3Q0dsobAdb71fXtj7zqtDwQA==",
       "dependencies": {
-        "@graphy/core.class.writable": "^4.3.4",
-        "@graphy/core.data.factory": "^4.3.4",
+        "@graphy/core.class.writable": "^4.3.7",
+        "@graphy/core.data.factory": "^4.3.7",
         "big-integer": "^1.6.48"
       },
       "engines": {
@@ -139,45 +139,45 @@
       }
     },
     "node_modules/@graphy/content.xml.scribe": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@graphy/content.xml.scribe/-/content.xml.scribe-4.3.4.tgz",
-      "integrity": "sha512-SkcQB5lBzFs73KupxiLgpsdtblU7W8AtalWEVeHEXq7RaQSi/ogE3d/6kTXYbMghdDHr2aGRpuHA+epivbfY5w==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@graphy/content.xml.scribe/-/content.xml.scribe-4.3.7.tgz",
+      "integrity": "sha512-V6Ezv7jN4HGQ8a2nQmheDh+AmQ4kq9Rn4fvDmdozbMeDv9zkEyg6tA0/KGnyeOAVpZFQLv8mYfvsWMxMXh7sCw==",
       "dependencies": {
-        "@graphy/core.class.writable": "^4.3.4",
-        "@graphy/core.data.factory": "^4.3.4"
+        "@graphy/core.class.writable": "^4.3.7",
+        "@graphy/core.data.factory": "^4.3.7"
       },
       "engines": {
         "node": ">=8.4.0"
       }
     },
     "node_modules/@graphy/core.class.scribable": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@graphy/core.class.scribable/-/core.class.scribable-4.3.4.tgz",
-      "integrity": "sha512-miZ/rYApkl6jLIxRUWlh0KxDaV2GQVzY9Ejn1zJ71FxYfRfkQRf6ToV7aKQfySlkehFfBrVnzHe9WgZqNQz6Mg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@graphy/core.class.scribable/-/core.class.scribable-4.3.7.tgz",
+      "integrity": "sha512-XOR4hQOKiy34/q8svdcOzgcao27tClebSzpNaOfvdxSOC/E7plOhaLfVtWxPjfIbMJs7OtVihlyXEtD22Xnm1w==",
       "dependencies": {
-        "@graphy/core.data.factory": "^4.3.4",
-        "@graphy/core.iso.stream": "^4.3.4"
+        "@graphy/core.data.factory": "^4.3.7",
+        "@graphy/core.iso.stream": "^4.3.7"
       },
       "engines": {
         "node": ">=8.4.0"
       }
     },
     "node_modules/@graphy/core.class.writable": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@graphy/core.class.writable/-/core.class.writable-4.3.4.tgz",
-      "integrity": "sha512-B1dhE/Kg/jVgXUW7scgKVfNJC5IHs7tT81DZRs7Vt6zdqwM4bi3fgEfUb2dTe40PetUY7gu5qR2sXXn06UtoQw==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@graphy/core.class.writable/-/core.class.writable-4.3.7.tgz",
+      "integrity": "sha512-vUvYP9Sine5j9epaOlmkZ0Mll2Vlh/N3zc7weRlSnxNm2HhT/LhzF8PSCZyPg17rwpTabrjKW/Rj0xwQUqeEGQ==",
       "dependencies": {
-        "@graphy/core.class.scribable": "^4.3.4",
-        "@graphy/core.data.factory": "^4.3.4"
+        "@graphy/core.class.scribable": "^4.3.7",
+        "@graphy/core.data.factory": "^4.3.7"
       },
       "engines": {
         "node": ">=8.4.0"
       }
     },
     "node_modules/@graphy/core.data.factory": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@graphy/core.data.factory/-/core.data.factory-4.3.4.tgz",
-      "integrity": "sha512-IH/WkKG6kqfqNGgHIAseYXHkQTvWvjQsuDrfy+1IvOhFzJC8hRhqcBlse7ik4Cc7lzoWZWd6alQU3RA89D7nmw==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@graphy/core.data.factory/-/core.data.factory-4.3.7.tgz",
+      "integrity": "sha512-6uiNrClDnlfN52B8f0ZBjnyETXiCyYOyIUET2aGFTG+TXZTsiO1WcinsIo36YPt29i+boCDf0ldYDKhPKAibdw==",
       "dependencies": {
         "uri-js": "^4.4.0"
       },
@@ -186,9 +186,9 @@
       }
     },
     "node_modules/@graphy/core.iso.stream": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@graphy/core.iso.stream/-/core.iso.stream-4.3.4.tgz",
-      "integrity": "sha512-b66gmPVFC1a6RflI423Joq2gZ1BlIBfr2CiKChSzqlAYgzFWqQSKcI6ECP7gctZdezNc3h54t1+FljxPef3Ufg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@graphy/core.iso.stream/-/core.iso.stream-4.3.7.tgz",
+      "integrity": "sha512-Rr7C+pPYmFVUGqP8OnYPh7D6VnwucT4LUQBDvlni4OSB9Px0QEenlUBTyqcfIByDTcDNb8fFek9qyjjrO6zlNQ==",
       "dependencies": {
         "readable-stream": "^3.6.0"
       },
@@ -234,19 +234,19 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@lit-labs/ssr": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr/-/ssr-3.1.8.tgz",
-      "integrity": "sha512-3++/wRaue1GuFTZKDNhvnBIIUBJcKjnv+YeVWjQNETH/qcoTApmS88rzZvJENri84Vq+JonfF7dDTtHtenDU2A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr/-/ssr-3.2.0.tgz",
+      "integrity": "sha512-5ZwVMEpYCHI5MF7+5ER3IvOyDjJimq/nzKtV4momqSKr3a/9gEFouHzTDogwaYoOwIBBtO8jl5SX2Vsb0kfZgA==",
       "dependencies": {
-        "@lit-labs/ssr-client": "^1.1.4-pre.0",
-        "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0",
-        "@lit/reactive-element": "^2.0.0",
+        "@lit-labs/ssr-client": "^1.1.4",
+        "@lit-labs/ssr-dom-shim": "^1.1.2",
+        "@lit/reactive-element": "^1.6.1 || ^2.0.0",
         "@parse5/tools": "^0.3.0",
         "@types/node": "^16.0.0",
         "enhanced-resolve": "^5.10.0",
-        "lit": "^3.0.0",
-        "lit-element": "^4.0.0",
-        "lit-html": "^3.0.0",
+        "lit": "^3.1.0",
+        "lit-element": "^3.3.0 || ^4.0.0",
+        "lit-html": "^3.1.0",
         "node-fetch": "^3.2.8",
         "parse5": "^7.1.1"
       },
@@ -255,23 +255,13 @@
       }
     },
     "node_modules/@lit-labs/ssr-client": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-client/-/ssr-client-1.1.4.tgz",
-      "integrity": "sha512-LJUi1/Run6iLTfE3QlX0aGzuTBWOmvBQet2ushSgc8iE1X5bWFLii2QhpMb9rw3or3OrUmXjEEI/AzWaehbMAg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-client/-/ssr-client-1.1.5.tgz",
+      "integrity": "sha512-rAXd2OsuxfGA579RiDS2YQSm1HreE8knQHj+fcMhGIPYenBoW4M70Yl8K3a35MSLlpQnnF//s2TPfkHFmy2RhA==",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0",
-        "lit": "^3.0.0",
-        "lit-html": "^3.0.0"
-      }
-    },
-    "node_modules/@lit-labs/ssr-client/node_modules/lit": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.0.0.tgz",
-      "integrity": "sha512-nQ0teRzU1Kdj++VdmttS2WvIen8M79wChJ6guRKIIym2M3Ansg3Adj9O6yuQh2IpjxiUXlNuS81WKlQ4iL3BmA==",
-      "dependencies": {
-        "@lit/reactive-element": "^2.0.0",
-        "lit-element": "^4.0.0",
-        "lit-html": "^3.0.0"
+        "@lit/reactive-element": "^1.6.1 || ^2.0.0",
+        "lit": "^2.7.0 || ^3.0.0",
+        "lit-html": "^2.7.0 || ^3.0.0"
       }
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
@@ -279,28 +269,18 @@
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz",
       "integrity": "sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g=="
     },
-    "node_modules/@lit-labs/ssr/node_modules/lit": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.0.0.tgz",
-      "integrity": "sha512-nQ0teRzU1Kdj++VdmttS2WvIen8M79wChJ6guRKIIym2M3Ansg3Adj9O6yuQh2IpjxiUXlNuS81WKlQ4iL3BmA==",
-      "dependencies": {
-        "@lit/reactive-element": "^2.0.0",
-        "lit-element": "^4.0.0",
-        "lit-html": "^3.0.0"
-      }
-    },
     "node_modules/@lit/reactive-element": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.0.tgz",
-      "integrity": "sha512-wn+2+uDcs62ROBmVAwssO4x5xue/uKD3MGGZOXL2sMxReTRIT0JXKyMXeu7gh0aJ4IJNEIG/3aOnUaQvM7BMzQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.2.tgz",
+      "integrity": "sha512-SVOwLAWUQg3Ji1egtOt1UiFe4zdDpnWHyc5qctSceJ5XIu0Uc76YmGpIjZgx9YJ0XtdW0Jm507sDvjOu+HnB8w==",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0"
+        "@lit-labs/ssr-dom-shim": "^1.1.2"
       }
     },
     "node_modules/@messageformat/core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@messageformat/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-ppbb/7OYqg/t4WdFk8VAfZEV2sNUq3+7VeBAo5sKFhmF786sh6gB7fUeXa2qLTDIcTHS49HivTBN7QNOU5OFTg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@messageformat/core/-/core-3.3.0.tgz",
+      "integrity": "sha512-YcXd3remTDdeMxAlbvW6oV9d/01/DZ8DHUFwSttO3LMzIZj3iO0NRw+u1xlsNNORFI+u0EQzD52ZX3+Udi0T3g==",
       "dependencies": {
         "@messageformat/date-skeleton": "^1.0.0",
         "@messageformat/number-skeleton": "^1.0.0",
@@ -361,10 +341,46 @@
         "throttle-debounce": "^3.0.1"
       }
     },
+    "node_modules/@rdfjs-elements/editor-base/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@rdfjs-elements/editor-base/node_modules/lit": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/@rdfjs-elements/editor-base/node_modules/lit-element": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/@rdfjs-elements/editor-base/node_modules/lit-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/@rdfjs-elements/formats-pretty": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@rdfjs-elements/formats-pretty/-/formats-pretty-0.6.3.tgz",
-      "integrity": "sha512-3tyPluVg0c4ZPoNelGkm/vnPBwq273b+xqmYghblpiqudT/7+tiqy8VC4roxyLrLO+a7AwcFaUNdyo4fVTD3Bw==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@rdfjs-elements/formats-pretty/-/formats-pretty-0.6.4.tgz",
+      "integrity": "sha512-jyY/jkBaupKXvpCDIuDeO02xQmCD4WOZtGdtNg4OJQ2byyVhUg/VGWGAPSGbibuIy+ZjDzWLGwk2/P5yvP085A==",
       "dependencies": {
         "@graphy/content.nq.read": "^4.3.4",
         "@graphy/content.trig.read": "^4.3.4",
@@ -377,6 +393,7 @@
         "@rdfjs/term-map": "^2.0.0",
         "@tpluscode/rdf-ns-builders": ">=3.0.2",
         "@zazuko/formats-lazy": "^1.0.1",
+        "@zazuko/prefixes": "^2.0.0",
         "readable-stream": ">=3.6.0"
       }
     },
@@ -729,13 +746,13 @@
       }
     },
     "node_modules/@rdfjs/fetch-lite": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/fetch-lite/-/fetch-lite-3.2.1.tgz",
-      "integrity": "sha512-cnCuSkEpMGsSbkd3+bIKheCKTDE4iBSGG6l/Inp0qg4y5WMLtcffKtSUzWhq09cAajm0dWs+5W3EGPNBqF5A4w==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/fetch-lite/-/fetch-lite-3.2.2.tgz",
+      "integrity": "sha512-hcdg9gvMgaOLPGS1LAYPjyS3rjQg2x8G/do+ZTlHjIHrAtRzXZCa0ui+pzoT98258RQzxEGqajY4ug4IqSuHZw==",
       "dependencies": {
         "is-stream": "^3.0.0",
         "nodeify-fetch": "^3.1.0",
-        "readable-stream": "^4.2.0"
+        "readable-stream": "^4.4.2"
       }
     },
     "node_modules/@rdfjs/formats-common": {
@@ -986,91 +1003,102 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
     },
     "node_modules/@tpluscode/rdf-ns-builders": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-4.1.1.tgz",
-      "integrity": "sha512-HBwX0LWmLiwHikck7nbE7+b2kz45DAEs5+dfb/PCyg9kmHrUEYYAWZfaisGfX95fT6ZcwpkTwDaRxlorGu/Vpw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-4.3.0.tgz",
+      "integrity": "sha512-x3uh9mYwAU+PrALaDKhVjml1TCCWWduo6J8rybd9SMEEAoooXq1MYb13MRputjRT/kYaFyCND7LMobzhxZ/+bg==",
       "dependencies": {
         "@rdfjs/data-model": "^2",
         "@rdfjs/namespace": "^2",
         "@rdfjs/types": "*",
         "@types/rdfjs__namespace": "^2.0.2",
-        "@zazuko/prefixes": "^2.0.0"
+        "@zazuko/prefixes": "^2.0.1"
       }
     },
     "node_modules/@types/clownface": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/clownface/-/clownface-2.0.1.tgz",
-      "integrity": "sha512-zn794UX/fXle6nZLlwrTAcXyq0JOS4dy/nmQFUgMD8gMSS1Fnm/PWRdWl+jOeWZRq+FM94fi0Wvdgub/LFAgcg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/clownface/-/clownface-2.0.4.tgz",
+      "integrity": "sha512-NAV4bUtQetmHf+vBIDdAcPmgC26ObDOPHB2jowhcMb6phRlcRPMRZ0YwY77p1Iic4K8htlnBquZS2ld4UFO6hA==",
       "peer": true,
       "dependencies": {
         "rdf-js": "^4.0.2"
       }
     },
     "node_modules/@types/http-link-header": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.3.tgz",
-      "integrity": "sha512-y8HkoD/vyid+5MrJ3aas0FvU3/BVBGcyG9kgxL0Zn4JwstA8CglFPnrR0RuzOjRCXwqzL5uxWC2IO7Ub0rMU2A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.5.tgz",
+      "integrity": "sha512-AxhIKR8UbyoqCTNp9rRepkktHuUOw3DjfOfDCaO9kwI8AYzjhxyrvZq4+mRw/2daD3hYDknrtSeV6SsPwmc71w==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/jsonld": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.10.tgz",
-      "integrity": "sha512-fEXxh7TnXYTPcbHb/p3bJ2V5CGpzwv7wCwQ4GsvyvbSufn8mVrCXNuw/L1WVFkBC9qUl4UgDA4LRV6B8SmAiEw=="
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.12.tgz",
+      "integrity": "sha512-y2EDlpPhuifmqcijoLV0zu9Pw3fd40RIZqpX4V0v7cq6vVFXjBOMhCGe2SlfTPzTZBJLZUFBidWshTYFfInvDQ=="
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.199",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
-      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg=="
+      "version": "4.14.201",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.201.tgz",
+      "integrity": "sha512-y9euML0cim1JrykNxADLfaG0FgD1g/yTHwUs/Jg9ZIU7WKj2/4IW9Lbb1WZbvck78W/lfGXFfe+u2EGfIJXdLQ=="
     },
     "node_modules/@types/lodash-es": {
-      "version": "4.17.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.9.tgz",
-      "integrity": "sha512-ZTcmhiI3NNU7dEvWLZJkzG6ao49zOIjEgIE0RgV7wbPxU0f2xT3VSAHw2gmst8swH6V0YkLRGp4qPlX/6I90MQ==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.11.tgz",
+      "integrity": "sha512-eCw8FYAWHt2DDl77s+AMLLzPn310LKohruumpucZI4oOFJkIgnlaJcy23OKMJxx4r9PeTF13Gv6w+jqjWQaYUg==",
       "dependencies": {
         "@types/lodash": "*"
       }
     },
     "node_modules/@types/n3": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.16.1.tgz",
-      "integrity": "sha512-CN20HKSW7d/5eUQ6BndBLFyE0Wju1a8f3IJiHXSw10A7S2Q8SXmKD04+LGULlR2snuxUTTIjD/zSGvjBJxM37Q==",
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.16.4.tgz",
+      "integrity": "sha512-6PmHRYCCdjbbBV2UVC/HjtL6/5Orx9ku2CQjuojucuHvNvPmnm6+02B18YGhHfvU25qmX2jPXyYPHsMNkn+w2w==",
       "dependencies": {
         "@rdfjs/types": "^1.1.0",
         "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
-      "version": "16.18.58",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.58.tgz",
-      "integrity": "sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA=="
+      "version": "16.18.61",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.61.tgz",
+      "integrity": "sha512-k0N7BqGhJoJzdh6MuQg1V1ragJiXTh8VUBAZTWjJ9cUq23SG0F0xavOwZbhiP4J3y20xd6jxKx+xNUhkMAi76Q=="
+    },
+    "node_modules/@types/rdf-dataset-ext": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/rdf-dataset-ext/-/rdf-dataset-ext-1.0.7.tgz",
+      "integrity": "sha512-7AiBJjpPRQCxxK1v3YHwaHMggreZCoscbWSUNee8nxHphgejzJfM2H1P5RmI1KN/PfSGYKvAvZ+YxEbumLjT8Q==",
+      "peer": true,
+      "dependencies": {
+        "@types/readable-stream": "*",
+        "rdf-js": "^4.0.2"
+      }
     },
     "node_modules/@types/rdfjs__data-model": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__data-model/-/rdfjs__data-model-2.0.5.tgz",
-      "integrity": "sha512-8UX/6aZg+6Qj+wBZwjpQSwMLf8w/wwvXSEFOeVrrVXi0nBT1DMUfpbXZkzP4KZn0v16ugdJKcFgvO9OPEZJ6NA==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__data-model/-/rdfjs__data-model-2.0.7.tgz",
+      "integrity": "sha512-ysEnLulluo12hQLPulSheQIFrU3J+cV0X46NGUFO+TVsMDO4oc25KdrGD+9UnVAlUZTKJO6YYKWbDCl7V/0ADA==",
       "peer": true,
       "dependencies": {
         "@rdfjs/types": "^1.0.1"
       }
     },
     "node_modules/@types/rdfjs__dataset": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-2.0.4.tgz",
-      "integrity": "sha512-N/7knA81eZGQ/tCqvdxVSmtb056YAg18H8w/rCmiQszBNDcAS1HtXMDNcoO2wgjBcY4wJojETMMnuKN+Bklb0w==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-2.0.7.tgz",
+      "integrity": "sha512-+GaYIL9C7N1N0HyH+obU4IXuL7DX+fXuf827aUQ2Vx2UghO47+OTxo2v3seEQj/1YHoHBfQFk5Y4P6Q7Ht4Hqw==",
       "peer": true,
       "dependencies": {
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@types/rdfjs__environment": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__environment/-/rdfjs__environment-0.1.8.tgz",
-      "integrity": "sha512-QlvYGPGVtV0Vnw6J6rusvcHYyWanz2g+wnkzFHL5+xnCKLotPEeMv+Z1dQDEUZ5safsHhZznOzrvK7HHxtngSg==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__environment/-/rdfjs__environment-0.1.10.tgz",
+      "integrity": "sha512-WKdRJV9Ji652e6Heg5O5456lDYyRZ8CNcaFBMOGq3dJRjiH14Tp/oPrGBh7X3vXipAV7OdJR0r4iIkQTK+ZeGw==",
       "peer": true,
       "dependencies": {
         "@rdfjs/types": "*",
+        "@types/node": "*",
         "@types/rdfjs__data-model": "*",
         "@types/rdfjs__dataset": "*",
         "@types/rdfjs__namespace": "*",
@@ -1080,11 +1108,12 @@
       }
     },
     "node_modules/@types/rdfjs__formats-common": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__formats-common/-/rdfjs__formats-common-3.1.1.tgz",
-      "integrity": "sha512-25/0HVqrss2tSeojFMfKSATigivdI7i0Mt0E25axwsraFrnRFGsIaH9YhqXGkpGQ+uk4BSnM1HvSarnYQbkkeQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__formats-common/-/rdfjs__formats-common-3.1.4.tgz",
+      "integrity": "sha512-+GlTKpKswQ8uh7+k19khEwBC0gcQVI1x7vP0M8a7JjH6+wV5SR7qVWC7i10bF/sEcs7/CpEaMWEl69fD6GBMrA==",
       "peer": true,
       "dependencies": {
+        "@types/node": "*",
         "@types/rdfjs__parser-jsonld": "*",
         "@types/rdfjs__parser-n3": "*",
         "@types/rdfjs__serializer-jsonld": "*",
@@ -1095,90 +1124,95 @@
       }
     },
     "node_modules/@types/rdfjs__namespace": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-2.0.6.tgz",
-      "integrity": "sha512-14FJ03wlMzgT9b+GD9X4celunFTJRzU3cxl69mXHrciW+my91FmjBsuyiiJCd0HWiVXE/PnbAcTjENHC0ocIFA==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-2.0.10.tgz",
+      "integrity": "sha512-xoVzEIOxcpyteEmzaj94MSBbrBFs+vqv05joMhzLEiPRwsBBDnhkdBCaaDxR1Tf7wOW0kB2R1IYe4C3vEBFPgA==",
       "dependencies": {
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@types/rdfjs__parser-jsonld": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__parser-jsonld/-/rdfjs__parser-jsonld-2.1.2.tgz",
-      "integrity": "sha512-9Hsq0IOMejj2ro8rZ2QOynAqYiWZFXIKzWpRrOK7ebB1wpqQlSsNN14XsrN17ORYLk86owZlTIVlmnd1lhJ4fA==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__parser-jsonld/-/rdfjs__parser-jsonld-2.1.5.tgz",
+      "integrity": "sha512-9nMtgSHRYSFXyHJfo85qvZRickfFzxl421XJfig7dWTooB2+XrMjGXcX8t8/J8wE/IE37AtEAaSn9XU97J0f8Q==",
       "dependencies": {
         "@types/jsonld": "*",
         "rdf-js": "^4.0.2"
       }
     },
     "node_modules/@types/rdfjs__parser-n3": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__parser-n3/-/rdfjs__parser-n3-2.0.2.tgz",
-      "integrity": "sha512-PKD6b2WEBgO51FBSqiFJMhgaCObf3h5hAEKwWDP4YF6GNLmJpcFpfUxzaF8urMUV1jlhKDBPt9kvibzx//+5Mw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__parser-n3/-/rdfjs__parser-n3-2.0.5.tgz",
+      "integrity": "sha512-5dlonGC6UiSAsUSpCcnQHe2t8mZQu/NSubI6uiRoMQIL0g8cpwIoS63i2eczyKGV9jwZLJPxYQbQJp/Q6qPQyw==",
       "dependencies": {
         "rdf-js": "^4.0.2"
       }
     },
     "node_modules/@types/rdfjs__serializer-jsonld": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-jsonld/-/rdfjs__serializer-jsonld-2.0.1.tgz",
-      "integrity": "sha512-IK/PVr/jFh7BCElPwEBDmwJPsXRA/mRKNLPZRLkyOjcV4Y692HlEZIZiHDM3/XNHdg3w9YZVXGZS5SeSyW/0xQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-jsonld/-/rdfjs__serializer-jsonld-2.0.4.tgz",
+      "integrity": "sha512-podYtgQVJszg3eBlh7eUE3zuMi6BmKck01RXFu8G8tBSfC2Ihsee9Yki4zt8562q6CY9Ahz2PrHwLM5EQAW4CA==",
       "dependencies": {
         "rdf-js": "^4.0.2"
       }
     },
     "node_modules/@types/rdfjs__serializer-ntriples": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-ntriples/-/rdfjs__serializer-ntriples-2.0.2.tgz",
-      "integrity": "sha512-vKUZgbu5drOEHLqE+g2Fo6/fWSjuGBs78lkEt8r1G2NSghud/OCvfpaifZmvpr7Ei4xB2vr8knaUJjLqrgOw/g==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-ntriples/-/rdfjs__serializer-ntriples-2.0.5.tgz",
+      "integrity": "sha512-8tepsjLyI7jBFfe2aIUj36hrKo8Z7muXLyN1O7HyP6NfLMq/j5PtVh+2jRD48Ju31p1O8PTHAoLdOhwY6rSehg==",
       "dependencies": {
         "rdf-js": "^4.0.2"
       }
     },
     "node_modules/@types/rdfjs__sink-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__sink-map/-/rdfjs__sink-map-2.0.2.tgz",
-      "integrity": "sha512-tSD+qROedkd+Ne/indlU5zwwlVEmljnL6/ZoUYuioT6HhLVKCT8wAW2H8oXVk9DuV6TnYV4ZStlUE92HnOO/ng==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__sink-map/-/rdfjs__sink-map-2.0.5.tgz",
+      "integrity": "sha512-ycUBlOMbp9YpjrBrMwGv3uiqulOWgodess06cinYLxomOTc2ET9rEQklgM5rJqnu5WMsVP8SFG3fFw36/5hADQ==",
       "dependencies": {
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@types/rdfjs__term-map": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__term-map/-/rdfjs__term-map-2.0.6.tgz",
-      "integrity": "sha512-r+0wl1F6U6zlRsH8t0Z26xEoqL1P33j5X+wyhYC794IQ13e2NAIxUu1wqs3Oklv/pIJH0w6wg0UEG51pA8/RLw==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__term-map/-/rdfjs__term-map-2.0.9.tgz",
+      "integrity": "sha512-+9t8eotTAPJUPCrsgQ2QlwY+TvJy39mbMO/V//BkegY5G6PuaeB63GzcEpGDAC0xssQp7Dun0qHLBKCRuRKZQA==",
       "peer": true,
       "dependencies": {
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@types/rdfjs__term-set": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__term-set/-/rdfjs__term-set-2.0.5.tgz",
-      "integrity": "sha512-oRrW8wP71CCuB/v/uyAo5+lwBM174DkXb44YmjzGcvq7Pxonho5No8I15fNic51gQIas9g+/UbXa+5pWhVB+YQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__term-set/-/rdfjs__term-set-2.0.8.tgz",
+      "integrity": "sha512-yTGvrCwTlWyflWUf0IExTvU/T8sbNdo3JVQQ+tQIHTZJTAxMn5Vac7vPPJWudhHi3LU2/AuI8j/xas00Avmfxw==",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__traverser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__traverser/-/rdfjs__traverser-0.1.5.tgz",
+      "integrity": "sha512-tTpiM6lAddw+bGRDjhzwdpo1EQK73m8gYgMVNfO4OsevnuLZvQJeCJBckpuDC4H5HVAEwCapI0UlH9dVnZ9u5g==",
       "peer": true,
       "dependencies": {
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@types/readable-stream": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
-      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.6.tgz",
+      "integrity": "sha512-awa7+N1SSD9xz8ZvEUSO3/N3itc2PMH6Sca11HiX55TVsWiMaIgmbM76lN+2eZOrCQPiFqj0GmgsfsNtNGWoUw==",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "safe-buffer": "~5.1.1"
       }
     },
-    "node_modules/@types/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
     "node_modules/@types/trusted-types": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.4.tgz",
-      "integrity": "sha512-IDaobHimLQhjwsQ/NMwRVfa/yL7L/wriQPMhw1ZJall0KX6E1oxk29XMDeilW5qTIg5aoiqf5Udy8U/51aNoQQ=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.6.tgz",
+      "integrity": "sha512-HYtNooPvUY9WAVRBr4u+4Qa9fYD1ze2IUlAD3HoA6oehn1taGwBx3Oa52U4mTslTS+GAExKpaFu39Y5xUEwfjg=="
     },
     "node_modules/@vanillawc/wc-codemirror": {
       "version": "1.9.8",
@@ -1186,49 +1220,49 @@
       "integrity": "sha512-tdhzg+5MsTEml0at43IAYrwfwLY5l5r56I5l9WlDOheNjMZgAD5yoYYkK3RQY1Pi6JqLpVIxBi9LEqVQggHBPQ=="
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
-      "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.8.tgz",
+      "integrity": "sha512-hN/NNBUECw8SusQvDSqqcVv6gWq8L6iAktUR0UF3vGu2OhzRqcOiAno0FmBJWwxhYEXRlQJT5XnoKsVq1WZx4g==",
       "dependencies": {
-        "@babel/parser": "^7.21.3",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.23.0",
+        "@vue/shared": "3.3.8",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
-      "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.8.tgz",
+      "integrity": "sha512-+PPtv+p/nWDd0AvJu3w8HS0RIm/C6VGBIRe24b9hSyNWOAPEUosFZ5diwawwP8ip5sJ8n0Pe87TNNNHnvjs0FQ==",
       "dependencies": {
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-core": "3.3.8",
+        "@vue/shared": "3.3.8"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
-      "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.8.tgz",
+      "integrity": "sha512-WMzbUrlTjfYF8joyT84HfwwXo+8WPALuPxhy+BZ6R4Aafls+jDBnSz8PDz60uFhuqFbl3HxRfxvDzrUf3THwpA==",
       "dependencies": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/reactivity-transform": "3.3.4",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.23.0",
+        "@vue/compiler-core": "3.3.8",
+        "@vue/compiler-dom": "3.3.8",
+        "@vue/compiler-ssr": "3.3.8",
+        "@vue/reactivity-transform": "3.3.8",
+        "@vue/shared": "3.3.8",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0",
-        "postcss": "^8.1.10",
+        "magic-string": "^0.30.5",
+        "postcss": "^8.4.31",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
-      "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.8.tgz",
+      "integrity": "sha512-hXCqQL/15kMVDBuoBYpUnSYT8doDNwsjvm3jTefnXr+ytn294ySnT8NlsFHmTgKNjwpuFy7XVV8yTeLtNl/P6w==",
       "dependencies": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-dom": "3.3.8",
+        "@vue/shared": "3.3.8"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -1237,76 +1271,81 @@
       "integrity": "sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA=="
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
-      "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.8.tgz",
+      "integrity": "sha512-ctLWitmFBu6mtddPyOKpHg8+5ahouoTCRtmAHZAXmolDtuZXfjL2T3OJ6DL6ezBPQB1SmMnpzjiWjCiMYmpIuw==",
       "dependencies": {
-        "@vue/shared": "3.3.4"
+        "@vue/shared": "3.3.8"
       }
     },
     "node_modules/@vue/reactivity-transform": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
-      "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.8.tgz",
+      "integrity": "sha512-49CvBzmZNtcHua0XJ7GdGifM8GOXoUMOX4dD40Y5DxI3R8OUhMlvf2nvgUAcPxaXiV5MQQ1Nwy09ADpnLQUqRw==",
       "dependencies": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.23.0",
+        "@vue/compiler-core": "3.3.8",
+        "@vue/shared": "3.3.8",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0"
+        "magic-string": "^0.30.5"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
-      "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.8.tgz",
+      "integrity": "sha512-qurzOlb6q26KWQ/8IShHkMDOuJkQnQcTIp1sdP4I9MbCf9FJeGVRXJFr2mF+6bXh/3Zjr9TDgURXrsCr9bfjUw==",
       "dependencies": {
-        "@vue/reactivity": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/reactivity": "3.3.8",
+        "@vue/shared": "3.3.8"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
-      "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.8.tgz",
+      "integrity": "sha512-Noy5yM5UIf9UeFoowBVgghyGGPIDPy1Qlqt0yVsUdAVbqI8eeMSsTqBtauaEoT2UFXUk5S64aWVNJN4MJ2vRdA==",
       "dependencies": {
-        "@vue/runtime-core": "3.3.4",
-        "@vue/shared": "3.3.4",
-        "csstype": "^3.1.1"
+        "@vue/runtime-core": "3.3.8",
+        "@vue/shared": "3.3.8",
+        "csstype": "^3.1.2"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
-      "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.8.tgz",
+      "integrity": "sha512-zVCUw7RFskvPuNlPn/8xISbrf0zTWsTSdYTsUTN1ERGGZGVnRxM2QZ3x1OR32+vwkkCm0IW6HmJ49IsPm7ilLg==",
       "dependencies": {
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-ssr": "3.3.8",
+        "@vue/shared": "3.3.8"
       },
       "peerDependencies": {
-        "vue": "3.3.4"
+        "vue": "3.3.8"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
-      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.8.tgz",
+      "integrity": "sha512-8PGwybFwM4x8pcfgqEQFy70NaQxASvOC5DJwLQfpArw1UDfUXrJkdxD3BhVTMS+0Lef/TU7YO0Jvr0jJY8T+mw=="
     },
     "node_modules/@zazuko/env": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@zazuko/env/-/env-1.5.1.tgz",
-      "integrity": "sha512-NOYwQ9+g1ngIoSFtBocyZ+kxNKMKREXbAuT/mf5z+GNyO6H6Iylz5zEKZ+UU3YIsg1g099bMqg75vAB4JWrBhQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@zazuko/env/-/env-1.10.1.tgz",
+      "integrity": "sha512-+2O/hJVBQbwhDaB0+5XHevSsVAjLQEx/Au5eE4WhS9BIDBg1kG+F3UpGjFyHnWrzL7luFdysA32g+lzgEmXz7w==",
       "dependencies": {
         "@rdfjs/dataset": "^2.0.1",
         "@rdfjs/environment": "^0.1.2",
+        "@rdfjs/traverser": "^0.1.2",
         "@tpluscode/rdf-ns-builders": "^4.1.0",
+        "@zazuko/prefixes": "^2.1.0",
         "clownface": "^2.0.1",
+        "get-stream": "^8.0.1",
         "rdf-dataset-ext": "^1.1.0"
       },
       "peerDependencies": {
         "@types/clownface": "^2.0.0",
+        "@types/rdf-dataset-ext": "^1",
         "@types/rdfjs__environment": "^0.1.7",
-        "@types/rdfjs__formats-common": "^3.1.0"
+        "@types/rdfjs__formats-common": "^3.1.0",
+        "@types/rdfjs__traverser": "^0.1.3"
       }
     },
     "node_modules/@zazuko/formats-lazy": {
@@ -1341,9 +1380,9 @@
       }
     },
     "node_modules/@zazuko/prefixes": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@zazuko/prefixes/-/prefixes-2.0.0.tgz",
-      "integrity": "sha512-WicT6lMnWFaaxudoBhccRzUOxrej0Tk5jwn9oGj308MP2Dlsqh8f6EEJdGu+nXYp3M1NLLokXbtZpTvtDM11PQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@zazuko/prefixes/-/prefixes-2.1.0.tgz",
+      "integrity": "sha512-dm0/YBNzuwJUm8cXoF3Dn9DfQetnRDaOJ8NdlgLY645OaUddCzUAAYcanm+xZmEo1SWX+/Tp3jbScwCaN2b/aQ=="
     },
     "node_modules/@zazuko/rdf-entity-webcomponent": {
       "version": "0.7.7",
@@ -1358,6 +1397,42 @@
         "clownface": "^2.0.0",
         "lit": "^2.8.0",
         "n3": "^1.17.1"
+      }
+    },
+    "node_modules/@zazuko/rdf-entity-webcomponent/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@zazuko/rdf-entity-webcomponent/node_modules/lit": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/@zazuko/rdf-entity-webcomponent/node_modules/lit-element": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/@zazuko/rdf-entity-webcomponent/node_modules/lit-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/@zazuko/rdf-vocabularies": {
@@ -1524,32 +1599,31 @@
       }
     },
     "node_modules/@zazuko/trifid-entity-renderer": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@zazuko/trifid-entity-renderer/-/trifid-entity-renderer-0.5.1.tgz",
-      "integrity": "sha512-AMQPHA2tfTKF8QHnRw5rq+MAjMrthALjfMj6AoDzcJGQcchEI9PXyqhOWJQU6/SyDpYpxcuWObP+fP1lXug22g==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@zazuko/trifid-entity-renderer/-/trifid-entity-renderer-0.6.1.tgz",
+      "integrity": "sha512-k45dw0eV1KOsVXzL6j0/qtQk0KWocaB9lnpGN9hspTLl2CWUsiiFubsqBgzW6YV9OPD+E2K1WRxGQ3vemSElgA==",
       "dependencies": {
-        "@lit-labs/ssr": "^3.1.6",
+        "@lit-labs/ssr": "^3.1.9",
         "@rdfjs/formats-common": "^3.1.0",
         "@rdfjs/to-ntriples": "^2.0.0",
-        "@zazuko/env": "^1.3.1",
+        "@zazuko/env": "^1.10.1",
+        "@zazuko/prefixes": "^2.1.0",
         "@zazuko/rdf-entity-webcomponent": "^0.7.7",
         "express": "^4.18.2",
         "hijackresponse": "^5.0.0",
-        "lit": "^2.8.0",
+        "lit": "^3.0.2",
         "p-queue": "^7.4.1",
-        "rdf-ext": "^2.3.0",
         "sparql-http-client": "^2.4.2",
-        "trifid-core": "^2.6.3"
+        "trifid-core": "^2.7.1"
       }
     },
     "node_modules/@zazuko/trifid-handle-redirects": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@zazuko/trifid-handle-redirects/-/trifid-handle-redirects-0.1.2.tgz",
-      "integrity": "sha512-gnq9wb2HH+KLV3jXLzPF+CJ8fTrXLvSWQjKWaZL7LD55GOPleMy+iz7Mmn1fh+SBfVHLWEdwvqsEfBBQWIbSvg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@zazuko/trifid-handle-redirects/-/trifid-handle-redirects-0.1.3.tgz",
+      "integrity": "sha512-K8zP2bTAcpBGlJlVxkPb5y5qXnIhmS47maI5vfxe0DrQDB47j3XVoWauJW7Ztgv421LB8d3WGdujWDaS7yg5CQ==",
       "dependencies": {
         "debug": "^4.3.4",
-        "rdf-ext": "^2.1.0",
-        "sparql-http-client": "^2.4.1"
+        "sparql-http-client": "^2.4.2"
       }
     },
     "node_modules/@zazuko/trifid-plugin-sparql-proxy": {
@@ -1785,11 +1859,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/basic-auth/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
     "node_modules/basic-ftp": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
@@ -1902,12 +1971,13 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+      "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.1",
+        "set-function-length": "^1.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2000,17 +2070,20 @@
       }
     },
     "node_modules/commander": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
@@ -2049,6 +2122,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/content-disposition/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/content-type": {
       "version": "1.0.5",
@@ -2097,9 +2189,9 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
     "node_modules/core-js": {
-      "version": "3.33.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.0.tgz",
-      "integrity": "sha512-HoZr92+ZjFEKar5HS6MC776gYslNOKHt75mEBKWKnPeFDpZ6nH5OeF3S6HFT1mUAUZKrzkez05VboaX8myjSuw==",
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.2.tgz",
+      "integrity": "sha512-XeBzWI6QL3nJQiHmdzbAOiMYqjrb7hwU7A39Qhvd/POSa/t9E1AeZyEZx3fNvp/vtM8zXwhoL0FsiS0hD0pruQ==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -2562,19 +2654,19 @@
       }
     },
     "node_modules/datatables.net": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.13.6.tgz",
-      "integrity": "sha512-rHNcnW+yEP9me82/KmRcid5eKrqPqW3+I/p1TwqCW3c/7GRYYkDyF6aJQOQ9DNS/pw+nyr4BVpjyJ3yoZXiFPg==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.13.8.tgz",
+      "integrity": "sha512-2pDamr+GUwPTby2OgriVB9dR9ftFKD2AQyiuCXzZIiG4d9KkKFQ7gqPfNmG7uj9Tc5kDf+rGj86do4LAb/V71g==",
       "dependencies": {
         "jquery": ">=1.7"
       }
     },
     "node_modules/datatables.net-dt": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-1.13.6.tgz",
-      "integrity": "sha512-0fBsUi8k5e+x5e+xA/Eb5stFr2PIkHgDnbhZs8ZDLvzzL975lCm6sqBAcsTsXKvF7yuBvaDTVBTF4wOMw7PrYw==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-1.13.8.tgz",
+      "integrity": "sha512-/ZPzr1hQ+domerlg/MbcQHqeeqxK9fsZmpRs1YeKxsdfr+UyHQTUiiOO7RqekppSLc7MPqxGnzKkCX9vAgqm0w==",
       "dependencies": {
-        "datatables.net": ">=1.13.4",
+        "datatables.net": "1.13.8",
         "jquery": ">=1.7"
       }
     },
@@ -2616,6 +2708,19 @@
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.1",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/degenerator": {
@@ -2914,6 +3019,25 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/express/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/fast-copy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
@@ -3151,9 +3275,12 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/fuse.js": {
       "version": "3.6.1",
@@ -3172,28 +3299,25 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+      "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
+        "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3237,6 +3361,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -3294,9 +3429,9 @@
       }
     },
     "node_modules/grapoi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/grapoi/-/grapoi-1.0.2.tgz",
-      "integrity": "sha512-YOlMOdFjFLURx268pV3rLMt9pDszbbxbYYUKRpGjbSJFt3ubxIOqB/70sl4o8mqmaW7OYvlY8jdilT9b5bs5qA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grapoi/-/grapoi-1.1.0.tgz",
+      "integrity": "sha512-3MglAX41WbagJHsdezc+b+PCTNaGhIHmJuMB22jgzQEtB0rGoKXjGA+B7J7z9dvFAwd1/Sl08hLeWNnq8lurzw==",
       "dependencies": {
         "@rdfjs/namespace": "^2.0.0",
         "@rdfjs/term-set": "^2.0.0"
@@ -3322,12 +3457,15 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
-      "engines": {
-        "node": ">= 0.4.0"
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-proto": {
@@ -3350,6 +3488,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/help-me": {
@@ -3627,13 +3776,12 @@
       }
     },
     "node_modules/jsonld-context-parser": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.3.1.tgz",
-      "integrity": "sha512-/JtA6fig0/RlPG/1mZ3JgsIOZVDVrG4YbyUTgO5FfeM+rffh8CIBPUHZrOM1YOpgcKefBs1T9RZvuPyc2MuSCg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.4.0.tgz",
+      "integrity": "sha512-ZYOfvh525SdPd9ReYY58dxB3E2RUEU4DJ6ZibO8AitcowPeBH4L5rCAitE2om5G1P+HMEgYEYEr4EZKbVN4tpA==",
       "dependencies": {
         "@types/http-link-header": "^1.0.1",
         "@types/node": "^18.0.0",
-        "canonicalize": "^1.0.1",
         "cross-fetch": "^3.0.6",
         "http-link-header": "^1.0.2",
         "relative-to-absolute-iri": "^1.0.5"
@@ -3643,14 +3791,17 @@
       }
     },
     "node_modules/jsonld-context-parser/node_modules/@types/node": {
-      "version": "18.18.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.4.tgz",
-      "integrity": "sha512-t3rNFBgJRugIhackit2mVcLfF6IRc0JE4oeizPQL8Zrm8n2WY/0wOdpOPhdtG0V9Q2TlW/axbF1MJ6z+Yj/kKQ=="
+      "version": "18.18.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.9.tgz",
+      "integrity": "sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/jsonld-streaming-parser": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.2.1.tgz",
-      "integrity": "sha512-MZCUrQe3pBO2pk2i3BpyW9Yn2oZoe2RCRpHZAJa88S6tRyxbe7XcjWfTKAZv35obDJDIREgot4723VhbClJELw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.3.0.tgz",
+      "integrity": "sha512-6aWiAsWGZioTB/vNQ3KenREz9ddEOliZoEETi+jLrlL7+vkgMeHjnxyFlGe4UOCU7SVUNPhz/lgLGZjnxgVYtA==",
       "dependencies": {
         "@bergos/jsonparse": "^1.4.0",
         "@rdfjs/types": "*",
@@ -3659,9 +3810,18 @@
         "buffer": "^6.0.3",
         "canonicalize": "^1.0.1",
         "http-link-header": "^1.0.2",
-        "jsonld-context-parser": "^2.3.0",
+        "jsonld-context-parser": "^2.4.0",
         "rdf-data-factory": "^1.1.0",
         "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/jsonld-streaming-parser/node_modules/@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
       }
     },
     "node_modules/jsonld/node_modules/lru-cache": {
@@ -3780,55 +3940,29 @@
       }
     },
     "node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.0.tgz",
+      "integrity": "sha512-rzo/hmUqX8zmOdamDAeydfjsGXbbdtAFqMhmocnh2j9aDYqbu0fjXygjCa0T99Od9VQ/2itwaGrjZz/ZELVl7w==",
       "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
+        "@lit/reactive-element": "^2.0.0",
+        "lit-element": "^4.0.0",
+        "lit-html": "^3.1.0"
       }
     },
     "node_modules/lit-element": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.0.tgz",
-      "integrity": "sha512-N6+f7XgusURHl69DUZU6sTBGlIN+9Ixfs3ykkNDfgfTkDYGGOWwHAYBhDqVswnFGyWgQYR2KiSpu4J76Kccs/A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.2.tgz",
+      "integrity": "sha512-/W6WQZUa5VEXwC7H9tbtDMdSs9aWil3Ou8hU6z2cOKWbsm/tXPAcsoaHVEtrDo0zcOIE5GF6QgU55tlGL2Nihg==",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0",
+        "@lit-labs/ssr-dom-shim": "^1.1.2",
         "@lit/reactive-element": "^2.0.0",
-        "lit-html": "^3.0.0"
+        "lit-html": "^3.1.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.0.0.tgz",
-      "integrity": "sha512-DNJIE8dNY0dQF2Gs0sdMNUppMQT2/CvV4OVnSdg7BXAsGqkVwsE5bqQ04POfkYH5dBIuGnJYdFz5fYYyNnOxiA==",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
-      }
-    },
-    "node_modules/lit/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/lit/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/lit/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.0.tgz",
+      "integrity": "sha512-FwAjq3iNsaO6SOZXEIpeROlJLUlrbyMkn4iuv4f4u1H40Jw8wkeR/OUXZUHUoiYabGk8Y4Y0F/rgq+R4MrOLmA==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -3893,9 +4027,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.4",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.4.tgz",
-      "integrity": "sha512-Q/TKtsC5BPm0kGqgBIF9oXAs/xEf2vRKiIB4wCRQTJOQIByZ1d+NnUOotvJOvNpi5RNIgVOMC3pOuaP1ZTDlVg==",
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       },
@@ -4055,9 +4189,9 @@
       }
     },
     "node_modules/n3": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.17.1.tgz",
-      "integrity": "sha512-HlanMWpvN2kcTrFuU3GPObyY7qrVQWy2Hp7l4GSXJlcQapjQMR7OM4kCr788pTQzNIpiHS3JRvyZ2YUcYJ82rA==",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.17.2.tgz",
+      "integrity": "sha512-BxSM52wYFqXrbQQT5WUEzKUn6qpYV+2L4XZLfn3Gblz2kwZ09S+QxC33WNdVEQy2djenFL8SNkrjejEKlvI6+Q==",
       "dependencies": {
         "queue-microtask": "^1.1.2",
         "readable-stream": "^4.0.0"
@@ -4067,9 +4201,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -4159,9 +4293,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4343,9 +4477,9 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/pino": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.16.0.tgz",
-      "integrity": "sha512-UUmvQ/7KTZt/vHjhRrnyS7h+J7qPBQnpG80V56xmIC+o9IqYmQOw/UIny9S9zYDfRBR0ClouCr464EkBMIT7Fw==",
+      "version": "8.16.2",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.16.2.tgz",
+      "integrity": "sha512-2advCDGVEvkKu9TTVSa/kWW7Z3htI/sBKEZpqiHk6ive0i/7f5b1rsU8jn0aimxqfnSz5bj/nOYkwhBUn5xxvg==",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
@@ -4453,9 +4587,9 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/process-warning": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
-      "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.3.0.tgz",
+      "integrity": "sha512-N6mp1+2jpQr3oCFMz6SeHRGbv6Slb20bRhj4v3xR99HqNToAcOe1MFOp4tytyzOfJn+QtN8Rf7U/h2KAn4kC6g=="
     },
     "node_modules/promise-the-world": {
       "version": "1.0.1",
@@ -4523,9 +4657,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
       }
@@ -4636,9 +4770,9 @@
       }
     },
     "node_modules/rdf-ext": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/rdf-ext/-/rdf-ext-2.3.0.tgz",
-      "integrity": "sha512-/2bPbKidKNBItZA/iYgQXMZncK2T9zCHkH+yFMCaRfOay0qmqo7yN7t+VIGObXimQ66EYNRQANo/EMXIPEz9eA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/rdf-ext/-/rdf-ext-2.4.0.tgz",
+      "integrity": "sha512-JjPvoI64+o4k0odHX2e/sNLNz9skpvPnm3CQwC+e2S0BIasevWBnvgeepiMYj102Fz4u0h4cen9gEXMoTaD6NQ==",
       "dependencies": {
         "@rdfjs/data-model": "^2.0.1",
         "@rdfjs/dataset": "^2.0.1",
@@ -4652,40 +4786,8 @@
         "@rdfjs/term-set": "^2.0.1",
         "@rdfjs/to-ntriples": "^2.0.0",
         "@rdfjs/traverser": "^0.1.1",
-        "clownface": "^1.5.1",
         "grapoi": "^1.0.2",
         "readable-stream": "^4.3.0"
-      }
-    },
-    "node_modules/rdf-ext/node_modules/clownface": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/clownface/-/clownface-1.5.1.tgz",
-      "integrity": "sha512-Ko8N/UFsnhEGmPlyE1bUFhbRhVgDbxqlIjcqxtLysc4dWaY0A7iCdg3savhAxs7Lheb7FCygIyRh7ADYZWVIng==",
-      "dependencies": {
-        "@rdfjs/data-model": "^1.1.0",
-        "@rdfjs/namespace": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-ext/node_modules/clownface/node_modules/@rdfjs/data-model": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
-      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
-      "dependencies": {
-        "@rdfjs/types": ">=1.0.1"
-      },
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      }
-    },
-    "node_modules/rdf-ext/node_modules/clownface/node_modules/@rdfjs/namespace": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-1.1.0.tgz",
-      "integrity": "sha512-utO5rtaOKxk8B90qzaQ0N+J5WrCI28DtfAY/zExCmXE7cOfC5uRI/oMKbLaVEPj2P7uArekt/T4IPATtj7Tjug==",
-      "dependencies": {
-        "@rdfjs/data-model": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/rdf-graph-abstract": {
@@ -4789,9 +4891,9 @@
       "integrity": "sha512-TxG2el1DVpWQrWt+/1+2AhC3pvSGjbm30LtVMGC2sWdXzxj4W/TeoTsz4nuT96JURKm0I/2Zj1Bw5k/xQ/3i7w=="
     },
     "node_modules/rdfxml-streaming-parser": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.2.3.tgz",
-      "integrity": "sha512-HoH8urnga+YQ5sDY9ufRb0wg6FvwR284sSXpZ+fJE5X5Oej6dfzkFer81uBNZzyNmzJR1TpMYMznyXEjPMLhCA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.3.0.tgz",
+      "integrity": "sha512-t8O4v7UUw4aRKIdro68p0YdpP/xbv6GGpEe05HAXbsTo4OTELx/vBzAciTP+P51O6TaywVSXPAsPyK9/sQRT8A==",
       "dependencies": {
         "@rdfjs/types": "*",
         "@rubensworks/saxes": "^6.0.1",
@@ -4801,6 +4903,15 @@
         "readable-stream": "^4.0.0",
         "relative-to-absolute-iri": "^1.0.0",
         "validate-iri": "^1.0.0"
+      }
+    },
+    "node_modules/rdfxml-streaming-parser/node_modules/@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
       }
     },
     "node_modules/react": {
@@ -4859,11 +4970,6 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
-    },
-    "node_modules/readable-error/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/readable-error/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -4977,23 +5083,9 @@
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/safe-identifier": {
       "version": "0.4.2",
@@ -5132,6 +5224,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+      "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "dependencies": {
+        "define-data-property": "^1.1.1",
+        "get-intrinsic": "^1.2.1",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setimmediate": {
@@ -5311,6 +5417,20 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/sparql-http-client/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/sparql-http-client/node_modules/nodeify-fetch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/nodeify-fetch/-/nodeify-fetch-2.2.2.tgz",
@@ -5335,11 +5455,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/sparql-http-client/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/sparql-http-client/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -5436,6 +5551,25 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/string-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
@@ -5462,11 +5596,6 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
-    },
-    "node_modules/string-replace-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/string-replace-stream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -5623,11 +5752,11 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/trifid": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/trifid/-/trifid-4.0.2.tgz",
-      "integrity": "sha512-hFjuHDmmPNNeYDgjbPHsMXeBgNH7x+C7nxWtSqU7wK55VSzLmtB2PiyDOwudYsqfLFZ9YlGVutsTSPqdPs4Gng==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/trifid/-/trifid-4.0.3.tgz",
+      "integrity": "sha512-Mt8VFcTciYdvTyk1tbYqWv1xCISlncf8jJGiSPz3nUytrlxUwmQjosbV6lsJw8Y12YR5yKDOwk68GpWuo1azZw==",
       "dependencies": {
-        "@zazuko/trifid-entity-renderer": "^0.5.0",
+        "@zazuko/trifid-entity-renderer": "^0.6.0",
         "@zazuko/trifid-handle-redirects": "^0.1.2",
         "@zazuko/trifid-plugin-sparql-proxy": "^1.1.1",
         "commander": "^11.0.0",
@@ -5637,7 +5766,7 @@
         "trifid-handler-sparql": "^2.1.1",
         "trifid-plugin-graph-explorer": "^1.0.2",
         "trifid-plugin-i18n": "^2.0.1",
-        "trifid-plugin-spex": "^1.1.3",
+        "trifid-plugin-spex": "^1.1.4",
         "trifid-plugin-yasgui": "^2.2.4"
       },
       "bin": {
@@ -5645,9 +5774,9 @@
       }
     },
     "node_modules/trifid-core": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/trifid-core/-/trifid-core-2.6.3.tgz",
-      "integrity": "sha512-VGz84aCnABLbSl724XUtWgy1aN3/H0SxNPBkhucnM5U3sm+P0+NyyB1YODVjkh6igkr8UZTEhkxE0TeFRZvirg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/trifid-core/-/trifid-core-2.7.1.tgz",
+      "integrity": "sha512-69PE/bTtCi3zUQkxrkdOJRwK3WvDebTYR110oVdACzPuHGOav5VNkgmhArM6Ye1i3VHakQWB2G3zxVBtRAu6gw==",
       "dependencies": {
         "absolute-url": "^1.2.2",
         "ajv": "^8.12.0",
@@ -5865,13 +5994,23 @@
       }
     },
     "node_modules/trifid-plugin-spex": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/trifid-plugin-spex/-/trifid-plugin-spex-1.1.3.tgz",
-      "integrity": "sha512-Nfc7gAphd0kmdsdeacGR/Xe+vivy/2JbboczV6I7egbpowJ80Jx+7RCbhrDKbVSWLz8QMyHZ3BC0WZZpCD+0Cg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/trifid-plugin-spex/-/trifid-plugin-spex-1.1.4.tgz",
+      "integrity": "sha512-D8JeNlhjxCIpGsHHeRDZNgkFmRsUfYUFeWSKNoB3JIvBr5E7o5a8hqkni6nGNCfsDcHZPHnCexyo0yBpwk7pmw==",
       "dependencies": {
         "@zazuko/spex": "^0.1.20",
         "absolute-url": "^1.2.2",
-        "import-meta-resolve": "^2.2.2"
+        "express": "^4.18.2",
+        "import-meta-resolve": "^3.0.0"
+      }
+    },
+    "node_modules/trifid-plugin-spex/node_modules/import-meta-resolve": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-3.1.1.tgz",
+      "integrity": "sha512-qeywsE/KC3w9Fd2ORrRDUw6nS/nLwZpXgfrOc2IILvZYnCaEMd+D56Vfg9k4G29gIeVi3XKql1RQatME8iYsiw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/trifid-plugin-yasgui": {
@@ -5886,9 +6025,9 @@
       }
     },
     "node_modules/trifid-plugin-yasgui/node_modules/import-meta-resolve": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-3.0.0.tgz",
-      "integrity": "sha512-4IwhLhNNA8yy445rPjD/lWh++7hMDOml2eHtd58eG7h+qK3EryMuuRbsHGPikCoAgIkkDnckKfWSk2iDla/ejg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-3.1.1.tgz",
+      "integrity": "sha512-qeywsE/KC3w9Fd2ORrRDUw6nS/nLwZpXgfrOc2IILvZYnCaEMd+D56Vfg9k4G29gIeVi3XKql1RQatME8iYsiw==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5934,15 +6073,20 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.25.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.25.4.tgz",
-      "integrity": "sha512-450yJxT29qKMf3aoudzFpIciqpx6Pji3hEWaXqXmanbXF58LTAGCKxcJjxMXWu3iG+Mudgo3ZUfDB6YDFd/dAw==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
+      "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
       "engines": {
         "node": ">=14.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -6003,15 +6147,23 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
-      "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.8.tgz",
+      "integrity": "sha512-5VSX/3DabBikOXMsxzlW8JyfeLKlG9mzqnWgLQLty88vdZL7ZJgrdgBOmrArwxiLtmS+lNNpPcBYqrhE6TQW5w==",
       "dependencies": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-sfc": "3.3.4",
-        "@vue/runtime-dom": "3.3.4",
-        "@vue/server-renderer": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-dom": "3.3.8",
+        "@vue/compiler-sfc": "3.3.8",
+        "@vue/runtime-dom": "3.3.8",
+        "@vue/server-renderer": "3.3.8",
+        "@vue/shared": "3.3.8"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vue-router": {
@@ -6132,9 +6284,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
-      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
       "engines": {
         "node": ">= 14"
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.2.8",
   "type": "module",
   "dependencies": {
-    "trifid": "^4.0.2"
+    "trifid": "^4.0.3"
   },
   "license": "UNLICENSED",
   "scripts": {

--- a/views/parameters.hbs
+++ b/views/parameters.hbs
@@ -3,10 +3,8 @@
     <h1>Rendering</h1>
     <p>This page demonstrates distinct rendering options.</p>
 
+    <h3>Basic</h3>
     <ul>
-
-      <h3>Basic</h3>
-
       <li>
         Technical cues:
         <a href="/test/people/3?technicalCues=false">false</a>
@@ -20,8 +18,10 @@
         -
         <a href="/snippets/a3?compactMode=true">true</a>
       </li>
+    </ul>
 
-      <h3>Labels</h3>
+    <h3>Labels</h3>
+    <ul>
       <li>
         Compact mode, objects
         <a href="/snippets/a3?compactMode=false">false</a>
@@ -35,52 +35,60 @@
         -
         <a href="/snippets/a4?compactMode=true">true</a>
       </li>
+    </ul>
 
-      <h3>Lists</h3>
+    <h3>Lists</h3>
+    <ul>
       <li>
         List with
         <a
           href="/snippets/a6?compactMode=false&embedLists=false&embedBlankNodes=false"
         >compactMode=false, embedLists=false, embedBlankNodes=false</a>
       </li>
+
       <li>
         List with
         <a
           href="/snippets/a6?compactMode=false&embedLists=false&embedBlankNodes=true"
         >compactMode=false, embedLists=false, embedBlankNodes=true</a>
       </li>
+
       <li>
         List with
         <a
           href="/snippets/a6?compactMode=false&embedLists=true&embedBlankNodes=true"
         >compactMode=false, embedLists=true, embedBlankNodes=true</a>
       </li>
+
       <li>
         List with
         <a
           href="/snippets/a6?compactMode=true&embedLists=true&embedBlankNodes=true"
         >compactMode=true, embedLists=true, embedBlankNodes=true</a>
       </li>
+    </ul>
 
-      <h3>Languages</h3>
+    <h3>Languages</h3>
+    <ul>
       <li>
         <a href="/adams/eudora?highlightLanguage=fr">French</a>
         selected
       </li>
+
       <li>
         <a href="/adams/eudora?highlightLanguage=es">Spanish</a>
         selected
       </li>
+    </ul>
 
-      <li>
-        Show named graphs:
-        <a href="/test/people/3?showNamedGraphs=false">false</a>
-        -
-        <a href="/test/people/3?showNamedGraphs=true">true</a>
-      </li>
+    <h3>Named graphs</h3>
+    <ul>
+      <li><a href="/test/people/3?showNamedGraphs=false">Do not show named graphs</a></li>
+      <li><a href="/test/people/3?showNamedGraphs=true">Show named graphs</a></li>
+    </ul>
 
-      <h3>Node embedding</h3>
-
+    <h3>Node embedding</h3>
+    <ul>
       <li>
         Embed blanks:
         <a href="/wonderland/WhiteRabbit?embedBlankNodes=false">false</a>
@@ -92,46 +100,48 @@
         Example with
         <a href="/test/ladder/1">20 levels deep</a>, where maxDeep is 3.
       </li>
+
       <li>
         setting
         <a href="/test/ladder/1?maxLevel=1">maxDeep 1</a>
         will flatten the list
       </li>
+    </ul>
 
-      <h3>Redirect handler</h3>
-
+    <h3>Redirect handler</h3>
+    <ul>
       <li>
         See the
         <a
           href="/file/builds/pipelines/ld.zazuko.com/datasets/redirect.ttl"
-        >example</a></li>
+        >example</a>
+      </li>
+    </ul>
 
-      <h3>Pagination</h3>
-
+    <h3>Pagination</h3>
+    <ul>
       <li> See the example <a href="/test/people/">collection</a></li>
+    </ul>
 
-      <h3>Label loading</h3>
+    <h3>Label loading</h3>
+    <ul>
+      <li>Example of an <a href="/test/people/1">entity</a></li>
+      <li>Example of a <a href="/test/people/">collection</a></li>
+    </ul>
 
-      <p>
-        See examples of an
-        <a href="/test/people/1">entity</a>
-        and a
-        <a href="/test/people/">collection</a>
-      </p>
+    <p>
+      This instance is configured to fetch labels for entities that start with
+      "https://ld.zazuko.com", using two concurrent queries, 30 labels at a
+      time, with a maximum timeout or 1 second. It's configured to fetch
+      schema:name
+    </p>
 
-      <p>
-        This instance is configured to fetch labels for entities that start with
-        "https://ld.zazuko.com", using two concurrent queries, 30 labels at a
-        time, with a maximum timeout or 1 second. It's configured to fetch
-        schema:name
-      </p>
-
-      <h3> Feedback </h3>
+    <h3>Feedback</h3>
+    <ul>
       <li>
         Debug
-        <a href="/test/people/3?debug=true"> true</a>
+        <a href="/test/people/3?debug=true">true</a>
       </li>
-
     </ul>
 
     <p><a href="/">Go back to the homepage</a></p>

--- a/views/parameters.hbs
+++ b/views/parameters.hbs
@@ -1,124 +1,140 @@
 <div class="trifid-content">
-    <div class="container">
-        <h1>Rendering</h1>
-        <p>This page demonstrates distinct rendering options.</p>
+  <div class="container">
+    <h1>Rendering</h1>
+    <p>This page demonstrates distinct rendering options.</p>
 
-        <ul>
+    <ul>
 
-            <h3>Basic</h3>
+      <h3>Basic</h3>
 
-            <li>
-                Technical cues:
-                <a href="/test/people/3?technicalCues=false">false</a>
-                -
-                <a href="/test/people/3?technicalCues=true">true</a>
-            </li>
+      <li>
+        Technical cues:
+        <a href="/test/people/3?technicalCues=false">false</a>
+        -
+        <a href="/test/people/3?technicalCues=true">true</a>
+      </li>
 
-            <li>
-                Compact mode, objects
-                <a href="/snippets/a3?compactMode=false">false</a>
-                -
-                <a href="/snippets/a3?compactMode=true">true</a>
-            </li>
+      <li>
+        Compact mode, objects
+        <a href="/snippets/a3?compactMode=false">false</a>
+        -
+        <a href="/snippets/a3?compactMode=true">true</a>
+      </li>
 
-            <h3>Labels</h3>
-            <li>
-                Compact mode, objects
-                <a href="/snippets/a3?compactMode=false">false</a>
-                -
-                <a href="/snippets/a3?compactMode=true">true</a>
-            </li>
+      <h3>Labels</h3>
+      <li>
+        Compact mode, objects
+        <a href="/snippets/a3?compactMode=false">false</a>
+        -
+        <a href="/snippets/a3?compactMode=true">true</a>
+      </li>
 
-            <li>
-                Compact mode, properties
-                <a href="/snippets/a4?compactMode=false">false</a>
-                -
-                <a href="/snippets/a4?compactMode=true">true</a>
-            </li>
+      <li>
+        Compact mode, properties
+        <a href="/snippets/a4?compactMode=false">false</a>
+        -
+        <a href="/snippets/a4?compactMode=true">true</a>
+      </li>
 
+      <h3>Lists</h3>
+      <li>
+        List with
+        <a
+          href="/snippets/a6?compactMode=false&embedLists=false&embedBlankNodes=false"
+        >compactMode=false, embedLists=false, embedBlankNodes=false</a>
+      </li>
+      <li>
+        List with
+        <a
+          href="/snippets/a6?compactMode=false&embedLists=false&embedBlankNodes=true"
+        >compactMode=false, embedLists=false, embedBlankNodes=true</a>
+      </li>
+      <li>
+        List with
+        <a
+          href="/snippets/a6?compactMode=false&embedLists=true&embedBlankNodes=true"
+        >compactMode=false, embedLists=true, embedBlankNodes=true</a>
+      </li>
+      <li>
+        List with
+        <a
+          href="/snippets/a6?compactMode=true&embedLists=true&embedBlankNodes=true"
+        >compactMode=true, embedLists=true, embedBlankNodes=true</a>
+      </li>
 
-            <h3>Lists</h3>
-            <li>
-                List with <a href="/snippets/a6?compactMode=false&embedLists=false&embedBlankNodes=false">compactMode=false,
-                embedLists=false, embedBlankNodes=false</a>
-            </li>
-            <li>
-                List with <a href="/snippets/a6?compactMode=false&embedLists=false&embedBlankNodes=true">compactMode=false,
-                embedLists=false, embedBlankNodes=true</a>
-            </li>
-            <li>
-                List with <a href="/snippets/a6?compactMode=false&embedLists=true&embedBlankNodes=true">compactMode=false,
-                embedLists=true, embedBlankNodes=true</a>
-            </li>
-            <li>
-                List with <a href="/snippets/a6?compactMode=true&embedLists=true&embedBlankNodes=true">compactMode=true,
-                embedLists=true, embedBlankNodes=true</a>
-            </li>
+      <h3>Languages</h3>
+      <li>
+        <a href="/adams/eudora?highlightLanguage=fr">French</a>
+        selected
+      </li>
+      <li>
+        <a href="/adams/eudora?highlightLanguage=es">Spanish</a>
+        selected
+      </li>
 
-            <h3>Languages</h3>
-            <li>
-                <a href="/adams/eudora?highlightLanguage=fr">French</a> selected
-            </li>
-            <li>
-                <a href="/adams/eudora?highlightLanguage=es">Spanish</a> selected
-            </li>
+      <li>
+        Show named graphs:
+        <a href="/test/people/3?showNamedGraphs=false">false</a>
+        -
+        <a href="/test/people/3?showNamedGraphs=true">true</a>
+      </li>
 
+      <h3>Node embedding</h3>
 
+      <li>
+        Embed blanks:
+        <a href="/wonderland/WhiteRabbit?embedBlankNodes=false">false</a>
+        -
+        <a href="/wonderland/WhiteRabbit?embedBlankNodes=true">true</a>
+      </li>
 
-            <li>
-                Show named graphs:
-                <a href="/test/people/3?showNamedGraphs=false">false</a>
-                -
-                <a href="/test/people/3?showNamedGraphs=true">true</a>
-            </li>
+      <li>
+        Example with
+        <a href="/test/ladder/1">20 levels deep</a>, where maxDeep is 3.
+      </li>
+      <li>
+        setting
+        <a href="/test/ladder/1?maxLevel=1">maxDeep 1</a>
+        will flatten the list
+      </li>
 
-            <h3>Node embedding</h3>
+      <h3>Redirect handler</h3>
 
-            <li>
-                Embed blanks:
-                <a href="/wonderland/WhiteRabbit?embedBlankNodes=false">false</a>
-                -
-                <a href="/wonderland/WhiteRabbit?embedBlankNodes=true">true</a>
-            </li>
+      <li>
+        See the
+        <a
+          href="/file/builds/pipelines/ld.zazuko.com/datasets/redirect.ttl"
+        >example</a></li>
 
-            <li>
-                Example with
-                <a href="/test/ladder/1">20 levels deep</a>, where maxDeep is 3.
-            </li>
-            <li>
-                setting  <a href="/test/ladder/1?maxLevel=1">maxDeep 1</a> will flatten the list
-            </li>
+      <h3>Pagination</h3>
 
-            <h3>Redirect handler</h3>
+      <li> See the example <a href="/test/people/">collection</a></li>
 
-            <li> See the <a href="/file/builds/pipelines/ld.zazuko.com/datasets/redirect.ttl">example</a></li>
+      <h3>Label loading</h3>
 
-            <h3>Pagination</h3>
+      <p>
+        See examples of an
+        <a href="/test/people/1">entity</a>
+        and a
+        <a href="/test/people/">collection</a>
+      </p>
 
-            <li> See the example <a href="/test/people/">collection</a></li>
+      <p>
+        This instance is configured to fetch labels for entities that start with
+        "https://ld.zazuko.com", using two concurrent queries, 30 labels at a
+        time, with a maximum timeout or 1 second. It's configured to fetch
+        schema:name
+      </p>
 
+      <h3> Feedback </h3>
+      <li>
+        Debug
+        <a href="/test/people/3?debug=true"> true</a>
+      </li>
 
-            <h3>Label loading</h3>
+    </ul>
 
-            <p>
-                See examples of an <a href="/test/people/1">entity</a> and a <a href="/test/people/">collection</a>
-            </p>
-
-            <p>
-                This instance is configured to fetch labels for entities that start with "https://ld.zazuko.com", using
-                two concurrent queries, 30 labels at a time, with a maximum timeout or 1 second.
-
-                It's configured to fetch schema:name
-            </p>
-
-            <h3> Feedback </h3>
-            <li>
-                Debug <a href="/test/people/3?debug=true"> true</a>
-            </li>
-
-        </ul>
-
-        <p><a href="/">Go back to the homepage</a></p>
-        <p><a href="/sparql">Run some SPARQL query</a></p>
-    </div>
+    <p><a href="/">Go back to the homepage</a></p>
+    <p><a href="/sparql">Run some SPARQL query</a></p>
+  </div>
 </div>


### PR DESCRIPTION
This PR upgrades the Trifid version that is used to v4.0.3 and improves the HTML pages.